### PR TITLE
根据返回数据修正了id获取失败的问题

### DIFF
--- a/services/qcsh.py
+++ b/services/qcsh.py
@@ -52,7 +52,7 @@ class QcshService:
             'Users-Agent': USER_AGENT
         }, proxies=PROXY)
         ret_json = ret.json()
-        return ret_json.get("result").get("id")
+        return ret_json.get("result")[0].get("id")
 
     def updateStudyRecord(self, pid, student_number, subOrg=None):
         ret = requests.post(QCSH_STUDY_URL.format(access_token=self.accessToken), headers={


### PR DESCRIPTION
貌似由于上海市青年大学习后端返回数据`result`改成了列表，因此原本的脚本不能完成学习任务，对这个问题进行了修正。